### PR TITLE
fix: remove legacy endpoint from word fetch popover

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -576,7 +576,7 @@ Column {
 
               Text {
                 width: parent.width
-                text: "Definitions come from api.dictionaryapi.dev — no account or key required."
+                text: "Definitions come from *.wiktionary.org/w/api.php* — no account or key required."
                 color: Qt.darker(root.contentForeground, 1.7)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.caption


### PR DESCRIPTION
fix: remove legacy endpoint from word fetch popover

Updates the attribution text in the word fetch popover to reflect the migration from api.dictionaryapi.dev to Wiktionary's API.

### Changes:
- Panel.qml: Changed attribution text from "Definitions come from api.dictionaryapi.dev — no account or key required." to "Definitions come from *.wiktionary.org/w/api.php* — no account or key required."


This brings the UI attribution in line with the Wiktionary-based backend that has been the active data source.