### PR TITLE
feat: auto language detection

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -4,18 +4,20 @@
 
 // ---- Languages ----
 //
-// Data-driven list of supported target languages. Each entry carries a
-// BC-47-ish `value` (the dropdown's stored value), an English `label`
-// for the menu, and the native `wikiName` — the heading Wiktionary uses
-// for its own language section in that edition (e.g. "English" on
+// Data-driven list of supported Wiktionary editions. Each entry carries a
+// BCP-47-ish `value` (also the value detectLanguage() returns), an
+// English `label`, and the native `wikiName` — the heading Wiktionary
+// uses for its own language section in that edition (e.g. "English" on
 // en.wikt, "ภาษาไทย" on th.wikt, "日本語" on ja.wikt). The native name is
 // what the parser matches against, so getting it right is the
 // difference between a clean parse and an empty meaning[] on the
 // first lookup.
 //
-// Languages are listed roughly by coverage depth; the dropdown sorts
-// them alphabetically by English label. The Free Dictionary per-language
-// API isn't currently exercised — see apiBase below.
+// Languages are listed roughly by coverage depth. There is no manual
+// selector in the UI — detectLanguage() below picks the edition per
+// query, and langLabel()/langWikiName() resolve entries for display and
+// parsing. The Free Dictionary per-language API isn't currently
+// exercised — see apiBase below.
 var LANGUAGES = [
   { value: "ar", label: "Arabic",        wikiName: "Arabic" },
   { value: "bn", label: "Bengali",       wikiName: "Bengali" },
@@ -57,6 +59,102 @@ function langWikiName(value) {
 function defaultLanguage() { return "en" }
 
 function languages() { return LANGUAGES }
+
+// ---- Language auto-detection ----
+//
+// detectLanguage(text) picks the Wiktionary edition from the query's own
+// characters — the JS equivalent of counting unicodedata scripts per
+// char, hand-rolled as code-point ranges because the QML JS engine ships
+// no Unicode character-name API.
+//
+//   - Every non-Latin language in LANGUAGES owns a private Unicode
+//     block, so its first code point settles the call: Thai→th,
+//     Bengali→bn, Devanagari→hi, Cyrillic→ru, Hangul→ko, Kana→ja.
+//
+//   - Two blocks are shared between languages and get resolved by other
+//     evidence found in the same pass:
+//       * Han ideographs serve Japanese AND Chinese — any kana in the
+//         query tips the call to "ja", otherwise "zh".
+//       * Arabic script serves Arabic and Persian — letters only
+//         Persian uses (پ چ ژ گ ک ی, incl. presentation forms) tip the
+//         call to "fa", otherwise "ar".
+//
+//   - Latin-script queries carry no reliable signal (en fr de es … all
+//     share one alphabet; diacritic guessing misfires more than it
+//     helps), so they stay on English. en.wiktionary also hosts most
+//     foreign headwords under their own ==Language== sections, which
+//     the parser's first-level-2 fallback already handles.
+//
+// There is no manual override in the UI any more; this function decides
+// every lookup, and runLookup() feeds its result straight into
+// lookupArgs()/parseResponse().
+
+function detectLanguage(rawText) {
+  var text = String(rawText || "")
+  if (text.trim() === "") return defaultLanguage()
+
+  var sawHan = false
+  var sawKana = false
+  var sawArabic = false
+  var sawPersian = false
+
+  for (var i = 0; i < text.length; i++) {
+    var ch = text.charCodeAt(i)
+
+    // Hangul syllables + jamo blocks.
+    if ((ch >= 0xAC00 && ch <= 0xD7A3) ||
+        (ch >= 0x1100 && ch <= 0x11FF) ||
+        (ch >= 0x3130 && ch <= 0x318F)) return "ko"
+
+    // Kana: hiragana + katakana + halfwidth katakana.
+    if ((ch >= 0x3041 && ch <= 0x30FF) ||
+        (ch >= 0x31F0 && ch <= 0x31FF) ||
+        (ch >= 0xFF66 && ch <= 0xFF9D)) { sawKana = true; continue }
+
+    // CJK ideographs (shared ja/zh — resolved after the loop).
+    if ((ch >= 0x3400 && ch <= 0x4DBF) ||
+        (ch >= 0x4E00 && ch <= 0x9FFF) ||
+        (ch >= 0xF900 && ch <= 0xFAFF)) { sawHan = true; continue }
+
+    // Thai.
+    if (ch >= 0x0E01 && ch <= 0x0E5B) return "th"
+
+    // Bengali.
+    if (ch >= 0x0980 && ch <= 0x09FF) return "bn"
+
+    // Devanagari.
+    if (ch >= 0x0900 && ch <= 0x097F) return "hi"
+
+    // Cyrillic.
+    if ((ch >= 0x0400 && ch <= 0x04FF) ||
+        (ch >= 0x0500 && ch <= 0x052F)) return "ru"
+
+    // Arabic script (standard block + supplement + presentation forms).
+    if ((ch >= 0x0600 && ch <= 0x06FF) ||
+        (ch >= 0x0750 && ch <= 0x077F) ||
+        (ch >= 0xFB50 && ch <= 0xFDFF) ||
+        (ch >= 0xFE70 && ch <= 0xFEFF)) {
+      sawArabic = true
+      // Persian-only letters, incl. their isolated/initial/medial/final forms.
+      if (ch === 0x067E || ch === 0x0686 || ch === 0x0698 || ch === 0x06AF ||
+          ch === 0x06A9 || ch === 0x06CC ||
+          (ch >= 0xFB56 && ch <= 0xFB59) || (ch >= 0xFB7A && ch <= 0xFB7D) ||
+          (ch >= 0xFB8A && ch <= 0xFB8B) || (ch >= 0xFB92 && ch <= 0xFB95) ||
+          (ch >= 0xFB8E && ch <= 0xFB91) || (ch >= 0xFBFC && ch <= 0xFBFF)) {
+        sawPersian = true
+      }
+    }
+  }
+
+  // Shared-script resolutions.
+  if (sawKana) return "ja"
+  if (sawHan) return "zh"
+  if (sawArabic) return sawPersian ? "fa" : "ar"
+
+  // Latin script (or digits/punctuation only): no reliable per-language
+  // signal — stay on the English edition.
+  return defaultLanguage()
+}
 
 // ---- API layer ----
 //

--- a/Panel.qml
+++ b/Panel.qml
@@ -83,9 +83,10 @@ Panel {
   property string statusMessage: ""
   property int variants: 0               // > 1 when the API returned more than one entry object
 
-  // Target language for lookups. Driven by the dropdown in the popup
-  // header; default comes from Model.defaultLanguage so the panel and
-  // data layer stay in sync.
+  // Target language for lookups. Auto-detected per query by
+  // Model.detectLanguage() inside runLookup() — there is no manual
+  // selector any more. Kept as a property so the fetch and parse paths
+  // agree on one edition even across re-entry.
   property string language: Model.defaultLanguage ? Model.defaultLanguage() : "en"
 
   // ---- Fuzzy state. Populated only when the user's exact query was a 404
@@ -144,6 +145,18 @@ Panel {
     return root.entry ? String(root.entry.phonetic || "") : ""
   }
 
+  // Header tag showing where the answer came from and which edition was
+  // auto-detected ("Wiktionary · Thai"). Function (not a binding ternary)
+  // so a null entry short-circuits before property access — QML evaluates
+  // both arms of `?:` and null-derefs mid-fetch otherwise.
+  function sourceTagText() {
+    if (!root.entry) return ""
+    var src = Model.sourceLabel(root.entry)
+    if (src === "") return ""
+    var lang = root.entry.language ? Model.langLabel(root.entry.language) : ""
+    return lang !== "" ? src + " · " + lang : src
+  }
+
   // ---- Focus handling. The field owns initial focus; Esc redirects to close.
   function refreshFocus() {
     if (!root.opened) return
@@ -167,6 +180,10 @@ Panel {
       root.resetResults()
       return
     }
+    // Pick the Wiktionary edition from the query's own characters —
+    // Thai → th.wiktionary, kana → ja, Cyrillic → ru; Latin-script
+    // queries stay on the English edition.
+    root.language = Model.detectLanguage(q)
     var args = Model.lookupArgs(q, root.language)
     if (args.length === 0) return
 
@@ -328,10 +345,10 @@ Column {
       width: parent.width
       spacing: Style.space(14)
 
-        // ---------- Hero: title + entry summary (parts of speech) + lang dropdown
+        // ---------- Hero: title + entry summary
         Item {
           width: parent.width
-          implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight, languageDropdown.implicitHeight)
+          implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight)
 
           Text {
             id: heroIcon
@@ -347,7 +364,7 @@ Column {
             id: heroLabels
             anchors.left: heroIcon.right
             anchors.leftMargin: Style.space(14)
-            anchors.right: languageDropdown.left
+            anchors.right: parent.right
             anchors.rightMargin: Style.space(10)
             anchors.verticalCenter: parent.verticalCenter
             spacing: Style.space(2)
@@ -372,7 +389,7 @@ Column {
                 if (root.status === "loading") return "looking up…"
                 if (root.status === "notfound") return "no definition"
                 if (root.status === "error") return "couldn't reach the API"
-                return "look up a word"
+                return "look up a word — language is auto-detected"
               }
               color: Qt.darker(root.contentForeground, 1.4)
               font.family: root.contentFontFamily
@@ -381,42 +398,6 @@ Column {
               font.letterSpacing: 1.2
               elide: Text.ElideRight
               width: parent.width
-            }
-          }
-
-          // Language switcher in the top right of the popup. Data-driven
-          // from Model.languages() (sorted alphabetically by English
-          // label in JS) so adding a language is a one-entry edit.
-          // Picking one kicks off a fresh lookup when there's already a
-          // query, so changing language doesn't require retyping the
-          // word.
-          Dropdown {
-            id: languageDropdown
-            value: root.language
-            options: Model.languages()
-            showLabel: false
-            anchors.right: parent.right
-            anchors.verticalCenter: parent.verticalCenter
-            implicitWidth: Style.space(120)
-            onChanged: function(newValue) {
-              if (newValue === root.language) return
-              root.language = newValue
-              // The previously-shown entry (or in-flight lookup) was for
-              // the prior language and is no longer meaningful under the
-              // new one. Cancel any in-flight proc, clear the entry,
-              // empty the search field, and reset to idle so the user
-              // starts fresh with the new language.
-              if (lookupProc.running) lookupProc.running = false
-              var hadResult = root.status === "ok" || root.status === "notfound" ||
-                              root.status === "error" || root.status === "suggestions" ||
-                              root.status === "loading"
-              if (hadResult) {
-                root.resetResults()
-                root.programmaticEdit = true
-                searchField.text = ""
-                root.programmaticEdit = false
-                root.query = ""
-              }
             }
           }
         }
@@ -770,11 +751,11 @@ Column {
               visible: text !== ""
             }
 
-            // Small muted source tag (e.g. "Wiktionary") to make it obvious
-            // which data source filled the panel.
+            // Small muted tag (e.g. "Wiktionary · Thai") making it obvious
+            // which data source and auto-detected edition filled the panel.
             Text {
               id: sourceTag
-              text: root.entry ? Model.sourceLabel(entry) : ""
+              text: root.sourceTagText()
               color: Qt.darker(root.contentForeground, 1.55)
               font.family: root.contentFontFamily
               font.pixelSize: Style.font.caption

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ suggestions, and a global hotkey for looking up highlighted text anywhere
 on your system.
 
 Click the bar icon to open a search field. Type a word and press Enter to
-look it up. Use the language dropdown in the panel header to switch editions
-between [supported languages](#supported-languages). When no match exists,
-up to three similar words are suggested as clickable chips.
+look it up. The Wiktionary edition is picked automatically from the word's
+script — Thai, Japanese, Korean, Russian, Hindi, Arabic, Persian and more
+are detected from the characters themselves; Latin-script words look up on
+the English edition (see [supported languages](#supported-languages)).
+When no match exists, up to three similar words are suggested as clickable
+chips.
 
 ![Dictionary preview](preview.png)
 
@@ -36,7 +39,8 @@ omarchy bar move tristonarmstrong.dictionary --section center --after omarchy.cl
 
 - Click the bar icon to open the search panel
 - Type a word and press Enter to look it up
-- Use the language dropdown in the panel header to switch editions
+- The language edition is auto-detected from the word's script — no
+  selector to fiddle with
 - When no match exists, up to three similar words appear as chips you can
   click to retry
 - Press Esc to close the panel
@@ -110,33 +114,39 @@ when it's being removed). Remove it manually with the second command.
 
 23 Wiktionary editions, alphabetically by English label:
 
-| Language | Code |
+| Language | Script detected |
 |---|---|
-| Arabic | `ar` |
-| Bengali | `bn` |
-| Chinese | `zh` |
-| Dutch | `nl` |
-| English | `en` |
-| French | `fr` |
-| German | `de` |
-| Hindi | `hi` |
-| Indonesian | `id` |
-| Italian | `it` |
-| Japanese | `ja` |
-| Korean | `ko` |
-| Malay | `ms` |
-| Persian | `fa` |
-| Polish | `pl` |
-| Portuguese | `pt` |
-| Russian | `ru` |
-| Spanish | `es` |
-| Swahili | `sw` |
-| Swedish | `sv` |
-| Thai | `th` |
-| Turkish | `tr` |
-| Vietnamese | `vi` |
+| Arabic | Arabic script (without Persian-only letters) |
+| Bengali | Bengali |
+| Chinese | Han ideographs, no kana present |
+| Dutch | falls back to English edition |
+| English | default for all Latin-script words |
+| French | falls back to English edition |
+| German | falls back to English edition |
+| Hindi | Devanagari |
+| Indonesian | falls back to English edition |
+| Italian | falls back to English edition |
+| Japanese | Kana (hiragana/katakana), or Han with kana |
+| Korean | Hangul |
+| Malay | falls back to English edition |
+| Persian | Arabic script with Persian-only letters (پ چ ژ گ) |
+| Polish | falls back to English edition |
+| Portuguese | falls back to English edition |
+| Russian | Cyrillic |
+| Spanish | falls back to English edition |
+| Swahili | falls back to English edition |
+| Swedish | falls back to English edition |
+| Thai | Thai |
+| Turkish | falls back to English edition |
+| Vietnamese | falls back to English edition |
 
-To add another edition, append it to the `LANGUAGES` array in `Model.js`.
+Detection scans the query's Unicode blocks (`Model.detectLanguage`).
+Latin-script languages share one alphabet and can't be told apart
+reliably from a single word, so they run on the English edition — which
+also hosts headwords for most of them.
+
+To add another edition, append it to the `LANGUAGES` array in `Model.js`
+and, if it uses its own script, a block check inside `detectLanguage`.
 
 ## License
 

--- a/scripts/omarchy-dictionary-lookup
+++ b/scripts/omarchy-dictionary-lookup
@@ -31,10 +31,16 @@ wayland_display() {
 }
 
 # extract_word <string>
-#   Returns the first run of ASCII letters in $1, or empty string if none.
-#   Pure function — no I/O, no side effects.
+#   Returns the first run of Unicode letters (plus combining marks, which
+#   scripts like Thai and Devanagari need to spell whole words), or empty
+#   string if none. Pure function — no I/O, no side effects.
+#
+#   Runs grep under LC_ALL=C.utf8 because \p{L}/\p{M} only match multibyte
+#   characters when the engine knows the input is UTF-8; hotkey-spawned
+#   processes can't rely on LANG being set. C.utf8 ships with glibc on
+#   Arch, so it's always available.
 extract_word() {
-  printf '%s' "${1:-}" | grep -oP '[a-zA-Z]+' | head -n1 || true
+  printf '%s' "${1:-}" | LC_ALL=C.utf8 grep -aoP '[\p{L}\p{M}]+' | head -n1 || true
 }
 
 # read_selection

--- a/tests/lookup.test.js
+++ b/tests/lookup.test.js
@@ -108,10 +108,26 @@ test("whitespace-only returns empty", () => {
   assert.strictEqual(callExtractWord("   "), "");
 });
 
-test("unicode letters are excluded (script targets ASCII)", () => {
-  // café's "fé" has accented chars — grep -oP '[a-zA-Z]+' will stop at é
-  // because é is not in [a-zA-Z]. Verify the contract: ASCII letters only.
-  assert.strictEqual(callExtractWord("café"), "caf");
+test("keeps accented Latin intact", () => {
+  assert.strictEqual(callExtractWord("café"), "café");
+});
+
+test("keeps Thai words whole (combining marks included)", () => {
+  // The vowel/tone marks are Unicode Mn (marks), not letters — without
+  // \p{M} in the class the run would split at them and lose them.
+  assert.strictEqual(callExtractWord("สวัสดี ครับ"), "สวัสดี");
+});
+
+test("keeps Devanagari conjuncts whole", () => {
+  assert.strictEqual(callExtractWord("(नमस्ते)"), "नमस्ते");
+});
+
+test("keeps Cyrillic words", () => {
+  assert.strictEqual(callExtractWord("\"привет\", he said"), "привет");
+});
+
+test("first word wins regardless of script", () => {
+  assert.strictEqual(callExtractWord("こんにちは world"), "こんにちは");
 });
 
 // ── wayland_display helper tests ─────────────────────────────────────────────
@@ -202,6 +218,36 @@ group("main flow — IPC dispatch");
 test("with a selection: calls 'search' with the extracted word", () => {
   var result = callMainFlow("hello world");
   assert.strictEqual(result, "-q tristonarmstrong.dictionary search hello");
+});
+
+test("with a non-Latin selection: searches the extracted word (regression)", () => {
+  // Regression: the old ASCII-only extractor turned a Thai highlight into
+  // an empty word and fell through to 'toggle' — no prefill, no language
+  // detection. It must dispatch 'search' with the Unicode word instead.
+  var result = callMainFlow("สวัสดี ครับ");
+  assert.strictEqual(result, "-q tristonarmstrong.dictionary search สวัสดี");
+});
+
+// The hotkey contract: ANY highlighted word, whatever its script, must be
+// piped into the search field via 'search <word>'. Only genuinely empty /
+// punctuation-only / digit-only selections may fall back to 'toggle'.
+group("main flow — any language pipes to the search field");
+
+[
+  ["hello world", "hello"],
+  ["สวัสดี ครับ", "สวัสดี"],
+  ["こんにちは、世界", "こんにちは"],
+  ["привет, как дела?", "привет"],
+  ["مرحبا بالعالم", "مرحبا"],
+  ["(नमस्ते)", "नमस्ते"],
+  ["café au lait", "café"],
+  ["안녕하세요 반갑습니다", "안녕하세요"],
+  ["寿司は好きです", "寿司は好きです"]
+].forEach(function (c) {
+  test("\"" + c[0] + "\" → search " + c[1], () => {
+    var result = callMainFlow(c[0]);
+    assert.strictEqual(result, "-q tristonarmstrong.dictionary search " + c[1]);
+  });
 });
 
 test("with punctuation-only selection: calls 'toggle' to open empty popup", () => {

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -32,6 +32,7 @@ var stripped = src
 // We need to add explicit export lines so Node can reach them.
 var PUBLIC_SYMBOLS = [
   "LANGUAGES","LANG_BY_VALUE","langLabel","langWikiName","defaultLanguage","languages",
+  "detectLanguage",
   "apiBase","lookupArgs","parseResponse","normalizeEntry","normalizeMeaning","normalizeDefinition","stringList",
   "parseSections","stripInlineHeaders","WIKT_POS_KEYS","WIKT_SKIP_DROP",
   "wiktCanonicalPos","wiktExtractIpa","wiktIsInflectionLine","wiktExtractDefs",
@@ -147,6 +148,95 @@ group("langWikiName", function () {
 
 group("defaultLanguage", function () {
   test("returns 'en'", function () { eq(M.defaultLanguage(), "en"); });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2b — detectLanguage
+// ═══════════════════════════════════════════════════════════════════════════
+group("detectLanguage — script detection (tier 1)", function () {
+  test("Thai → th",            function () { eq(M.detectLanguage("สวัสดี"), "th"); });
+  test("Bengali → bn",         function () { eq(M.detectLanguage("বাংলা"), "bn"); });
+  test("Devanagari → hi",      function () { eq(M.detectLanguage("नमस्ते"), "hi"); });
+  test("Cyrillic → ru",        function () { eq(M.detectLanguage("привет"), "ru"); });
+  test("Hangul → ko",          function () { eq(M.detectLanguage("안녕하세요"), "ko"); });
+  test("kana → ja",            function () { eq(M.detectLanguage("こんにちは"), "ja"); });
+  test("katakana loanword → ja", function () { eq(M.detectLanguage("コーヒー"), "ja"); });
+  test("han only → zh",        function () { eq(M.detectLanguage("你好"), "zh"); });
+  test("kana + han → ja (wins over han)", function () { eq(M.detectLanguage("寿司は好きです"), "ja"); });
+  test("Arabic plain → ar",    function () { eq(M.detectLanguage("مرحبا"), "ar"); });
+  test("Persian letter گ → fa", function () { eq(M.detectLanguage("سلام گربه"), "fa"); });
+  test("Persian letter پ → fa", function () { eq(M.detectLanguage("پارسی"), "fa"); });
+  test("mixed script: latin + kana + han → ja", function () { eq(M.detectLanguage("sushi お寿司"), "ja"); });
+  test("han + latin without kana → zh", function () { eq(M.detectLanguage("寿司 sushi"), "zh"); });
+});
+
+group("detectLanguage — Latin script falls back to en", function () {
+  test("plain ASCII → en",       function () { eq(M.detectLanguage("hello world"), "en"); });
+  test("accented Latin → en (città)", function () { eq(M.detectLanguage("città"), "en"); });
+  test("Spanish-looking Latin → en (señora)", function () { eq(M.detectLanguage("señora"), "en"); });
+  test("German-looking Latin → en (straße)",  function () { eq(M.detectLanguage("straße"), "en"); });
+  test("numbers only → en",      function () { eq(M.detectLanguage("12345"), "en"); });
+  test("empty string → en",      function () { eq(M.detectLanguage(""), "en"); });
+  test("whitespace → en",        function () { eq(M.detectLanguage("   "), "en"); });
+  test("null → en",              function () { eq(M.detectLanguage(null), "en"); });
+  test("undefined → en",         function () { eq(M.detectLanguage(undefined), "en"); });
+  test("result is always a valid LANGUAGES value", function () {
+    ["hello", "สวัสดี", "你好", "señor", "café", "123"].forEach(function (q) {
+      var v = M.detectLanguage(q);
+      assert(M.LANG_BY_VALUE[v], "invalid value for '" + q + "': " + v);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2c — detection → fetch routing (integration contract)
+// ═══════════════════════════════════════════════════════════════════════════
+// Locks in what runLookup() does at search time for ANY word entering the
+// field — typed, piped in by the hotkey script, or clicked as a suggestion
+// chip: Model.detectLanguage(word) picks the edition, and that value drives
+// lookupArgs()/parseResponse(). Pinning word → edition → URL here means no
+// future change can silently route a language to the wrong wiki.
+
+group("detectLanguage × lookupArgs — every word routes to its edition", function () {
+  [
+    ["hello", "en"],
+    ["สวัสดี", "th"],
+    ["বাংলা", "bn"],
+    ["नमस्ते", "hi"],
+    ["привет", "ru"],
+    ["안녕하세요", "ko"],
+    ["こんにちは", "ja"],
+    ["コーヒー", "ja"],
+    ["寿司", "zh"],
+    ["你好", "zh"],
+    ["مرحبا", "ar"],
+    ["گربه", "fa"],
+    ["señora", "en"] // Latin script stays on English even when accented
+  ].forEach(function (c) {
+    var word = c[0], expected = c[1];
+    test("\"" + word + "\" → " + expected + ".wiktionary.org", function () {
+      var lang = M.detectLanguage(word);
+      eq(lang, expected);
+      var url = M.lookupArgs(word, lang).slice(-1)[0];
+      assert(url.indexOf("https://" + expected + ".wiktionary.org/") === 0,
+        "expected " + expected + ".wiktionary.org, got: " + url);
+      assert(url.indexOf("titles=" + encodeURIComponent(word)) > -1,
+        "URL must carry the encoded word, got: " + url);
+    });
+  });
+
+  test("detected edition parses its own response shape (th round trip)", function () {
+    var lang = M.detectLanguage("สวัสดี");
+    eq(lang, "th");
+    var resp = JSON.stringify({ query: { pages: { "9": {
+      pageid: 9, title: "สวัสดี",
+      extract: "== ภาษาไทย ==\n=== คำนาม ===\nคำทักทายของคนไทย.\nใช้ต้อนรับผู้มาเยือน."
+    }}}});
+    var r = M.parseResponse(resp, lang);
+    eq(r.ok, true);
+    eq(r.entry.language, "th");
+    assert(r.entry.meanings.length >= 1);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -732,7 +822,7 @@ group("parseSections — edge cases", function () {
 // ═══════════════════════════════════════════════════════════════════════════
 group("manifest.json", function () {
   var manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "manifest.json"), "utf8"));
-  test("version is 1.1.0", function () { eq(manifest.version, "1.1.0"); });
+  test("version is 1.2.0", function () { eq(manifest.version, "1.2.0"); });
   test("id matches module name", function () { eq(manifest.id, "tristonarmstrong.dictionary"); });
   test("schemaVersion is 1", function () { eq(manifest.schemaVersion, 1); });
   test("kinds includes bar-widget", function () { assert(manifest.kinds.indexOf("bar-widget") > -1); });


### PR DESCRIPTION
## Summary

Replaces the manual language dropdown with automatic language detection based on Unicode script analysis. Users no longer need to select a language — the correct Wiktionary edition is picked from the characters themselves.

## Changes

### Model.js — `detectLanguage()` function
- Scans input text character-by-character using Unicode code point ranges
- Each non-Latin script maps to its Wiktionary edition: Thai→th, Bengali→bn, Devanagari→hi, Cyrillic→ru, Hangul→ko, Kana→ja
- Handles shared scripts:
  - Han ideographs: kana present → ja, otherwise → zh
  - Arabic script: Persian-only letters (پ چ ژ گ گ ی) → fa, otherwise → ar
- Latin-script words fall back to English edition (can't reliably distinguish en/fr/de/es from a single word)

### Panel.qml — UI updates
- Removed the manual language dropdown selector
- `runLookup()` now calls `Model.detectLanguage(q)` before fetching
- Added `sourceTagText()` to show detected edition in header (e.g. "Wiktionary · Thai")
- Status text updated to "look up a word — language is auto-detected"

### scripts/omarchy-dictionary-lookup — Unicode word extraction
- `extract_word()` updated from ASCII-only (`[a-zA-Z]+`) to full Unicode (`[\p{L}\p{M}]+`)
- Now correctly extracts Thai, Devanagari, Cyrillic, CJK words from hotkey selections
- Uses `LC_ALL=C.utf8` for reliable multibyte matching

### Tests
- 30+ new test cases for `detectLanguage()` covering all supported scripts
- Cross-script routing tests (word → edition → URL)
- Unicode extraction tests for Thai, Devanagari, Cyrillic, accented Latin
- Round-trip test: Thai word → detect → fetch → parse → meanings
- Regression test: non-Latin hotkey selections now pipe correctly to search

### README.md
- Updated usage instructions to reflect auto-detection
- Language table now shows "Script detected" instead of language codes
- Added note about adding new editions