### PR TITLE
fix: set textFormat: Text.PlainText on all lookup result Text items

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -819,6 +819,7 @@ Column {
 
                     Text {
                       text: modelData.partOfSpeech
+                      textFormat: Text.PlainText
                       color: Color.accent
                       font.family: root.contentFontFamily
                       font.pixelSize: Style.font.caption
@@ -863,6 +864,7 @@ Column {
                         Text {
                           width: parent.width - Style.space(20) - Style.space(8)
                           text: modelData.definition
+                          textFormat: Text.PlainText
                           color: root.contentForeground
                           font.family: root.contentFontFamily
                           font.pixelSize: Style.font.body
@@ -875,6 +877,7 @@ Column {
                         x: Style.space(20) + Style.space(8)
                         visible: modelData.example !== ""
                         text: "\"" + modelData.example + "\""
+                        textFormat: Text.PlainText
                         color: Qt.darker(root.contentForeground, 1.3)
                         font.family: root.contentFontFamily
                         font.pixelSize: Style.font.caption
@@ -888,6 +891,7 @@ Column {
                     visible: modelData.synonyms.length > 0
                     width: parent.width
                     text: "synonyms: " + modelData.synonyms.join(", ")
+                    textFormat: Text.PlainText
                     color: Qt.darker(root.contentForeground, 1.5)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
@@ -898,6 +902,7 @@ Column {
                     visible: modelData.antonyms.length > 0
                     width: parent.width
                     text: "antonyms: " + modelData.antonyms.join(", ")
+                    textFormat: Text.PlainText
                     color: Qt.darker(root.contentForeground, 1.5)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption


### PR DESCRIPTION
## Problem

Security review (omacom/omarchy-plugin-marketplace#3639) found that `Panel.qml` renders `modelData.partOfSpeech`, `modelData.definition`, and `modelData.example` — fields straight from the Wiktionary API response — in Qt Quick `Text` items with the default `AutoText` format. HTML-shaped content in an API entry therefore renders as rich text inside the `omarchy-shell` process and can load a remote image from it.

## Fix

Set `textFormat: Text.PlainText` on every `Text` element that displays lookup results:

- `modelData.partOfSpeech` (line 821)
- `modelData.definition` (line 865)
- `modelData.example` (line 877)
- `modelData.synonyms` (line 890)
- `modelData.antonyms` (line 900)

## Testing

- 278 tests passing (lint, model, lookup, install)
- No visual change — all fields are plain text from the API

Refs omacom/omarchy-plugin-marketplace#3639
