### PR TITLE
fix(security): manual hotkey install, PlainText echo, apiBase allowlist

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -56,35 +56,58 @@ BarWidget {
   onBarChanged: injectPanel()
   onSettingsChanged: injectPanel()
 
-  // ---- Auto-install the selection-lookup script. The hotkey path needs
-  //      `omarchy-dictionary-lookup` on $PATH; rather than ask the user to
-  //      copy it manually, we install it to ~/.local/bin/ on first load.
-  //      Hyprland binding is the only remaining manual step (see README).
+  // ---- Manual install for the selection-lookup script. The hotkey path
+  //      needs `omarchy-dictionary-lookup` on $PATH. The panel footer
+  //      offers an explicit "Install" button that calls
+  //      installHotkeyScript() — nothing is written to ~/.local/bin/
+  //      without the user clicking it.
   //
-  //      ~/.local/bin is the right home for it: it is the XDG user binary
-  //      directory and Omarchy puts it on PATH for both shells and Hyprland
-  //      bindings (see $OMARCHY_PATH/default/bash/env-bootstrap). Nothing
-  //      creates it on a fresh install, so the first stage below is mkdir -p
-  //      and the destination directory is never assumed to exist.
+  //      ~/.local/bin is the XDG user binary directory and Omarchy puts
+  //      it on PATH for both shells and Hyprland bindings (see
+  //      $OMARCHY_PATH/default/bash/env-bootstrap).
   //
   //      The install runs as three shell-free Process stages (mkdir, cmp,
   //      install) with paths passed as argv, never interpolated into an
   //      `sh -c` string — so spaces or unusual characters in $HOME or the
   //      plugin path can never break shell quoting. cmp exit 0 means the
-  //      installed copy is already identical, so the notify only fires when
-  //      install(1) actually ran and subsequent restarts are silent.
-  //      Failures are reported via console.warn instead of failing silently.
+  //      installed copy is already identical, so install(1) is skipped
+  //      and the status becomes "up-to-date". Failures are reported via
+  //      installStatus/installMessage and console.warn.
   //
   //      Qt.resolvedUrl returns a file:// URL which the filesystem can't read
   //      directly — strip the scheme so cmp/install see a plain path.
   function notify(title, body) {
-    var bin = Quickshell.env("OMARCHY_PATH") + "/bin/omarchy-notification-send"
+    var omarchyPath = Quickshell.env("OMARCHY_PATH") || ""
+    if (omarchyPath === "") {
+      console.warn("omarchy-dictionary notify: OMARCHY_PATH is empty, skipping notification")
+      return
+    }
+    var bin = omarchyPath + "/bin/omarchy-notification-send"
     Quickshell.execDetached([bin, title, body])
   }
 
   readonly property string homeDir: Quickshell.env("HOME") || ""
   readonly property string binDir: homeDir + "/.local/bin"
   readonly property string destPath: binDir + "/omarchy-dictionary-lookup"
+
+  // Install status surfaced to the panel footer. idle = never attempted
+  // this session, working = a stage is running, up-to-date = cmp matched,
+  // installed = install(1) ran, error = mkdir/cmp/install failed.
+  property string installStatus: "idle"
+  property string installMessage: ""
+
+  function installHotkeyScript() {
+    if (root.homeDir === "") {
+      root.installStatus = "error"
+      root.installMessage = "HOME is empty, cannot install."
+      console.warn("omarchy-dictionary install: HOME is empty, skipping script install")
+      return
+    }
+    if (root.installStatus === "working") return
+    root.installStatus = "working"
+    root.installMessage = "Installing…"
+    mkdirProc.running = true
+  }
 
   // Util.fileUrl encodes every path segment, so Qt.resolvedUrl returns a
   // percent-encoded URL.  decodeURIComponent turns it back into a real
@@ -104,6 +127,8 @@ BarWidget {
     }
     onExited: function(exitCode) {
       if (exitCode !== 0) {
+        root.installStatus = "error"
+        root.installMessage = "Could not create ~/.local/bin."
         console.warn("omarchy-dictionary install: mkdir failed for", root.binDir)
         return
       }
@@ -118,9 +143,14 @@ BarWidget {
       onRead: function(line) { console.warn("omarchy-dictionary install:", line) }
     }
     onExited: function(exitCode) {
-      // 0 = identical, stay silent. Anything else — differ (1) or
+      // 0 = identical, already installed. Anything else — differ (1) or
       // missing/unreadable (2) — means install.
-      if (exitCode !== 0) installProc.running = true
+      if (exitCode === 0) {
+        root.installStatus = "up-to-date"
+        root.installMessage = "Already installed and up to date."
+      } else {
+        installProc.running = true
+      }
     }
   }
 
@@ -132,18 +162,14 @@ BarWidget {
     }
     onExited: function(exitCode) {
       if (exitCode === 0) {
+        root.installStatus = "installed"
+        root.installMessage = "Installed to ~/.local/bin/omarchy-dictionary-lookup."
         root.notify("Dictionary", "Installed system script: ~/.local/bin/omarchy-dictionary-lookup")
       } else {
+        root.installStatus = "error"
+        root.installMessage = "Install failed."
         console.warn("omarchy-dictionary install: install failed for", root.destPath)
       }
-    }
-  }
-
-  Component.onCompleted: {
-    if (root.homeDir === "") {
-      console.warn("omarchy-dictionary install: HOME is empty, skipping script install")
-    } else {
-      mkdirProc.running = true
     }
   }
 

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -60,51 +60,92 @@ BarWidget {
   //      `omarchy-dictionary-lookup` on $PATH; rather than ask the user to
   //      copy it manually, we install it to ~/.local/bin/ on first load.
   //      Hyprland binding is the only remaining manual step (see README).
-  //      The install is idempotent: a quick cmp -s skips it when the script
-  //      already matches the bundled copy. The trailing echo only fires when
-  //      install(1) actually ran — we use that as the trigger for the
-  //      notification below, so subsequent restarts are silent.
   //
-  //      Qt.resolvedUrl returns a file:// URL which the shell can't read
-  //      directly — strip the scheme so install(1) sees a plain path.
+  //      ~/.local/bin is the right home for it: it is the XDG user binary
+  //      directory and Omarchy puts it on PATH for both shells and Hyprland
+  //      bindings (see $OMARCHY_PATH/default/bash/env-bootstrap). Nothing
+  //      creates it on a fresh install, so the first stage below is mkdir -p
+  //      and the destination directory is never assumed to exist.
+  //
+  //      The install runs as three shell-free Process stages (mkdir, cmp,
+  //      install) with paths passed as argv, never interpolated into an
+  //      `sh -c` string — so spaces or unusual characters in $HOME or the
+  //      plugin path can never break shell quoting. cmp exit 0 means the
+  //      installed copy is already identical, so the notify only fires when
+  //      install(1) actually ran and subsequent restarts are silent.
+  //      Failures are reported via console.warn instead of failing silently.
+  //
+  //      Qt.resolvedUrl returns a file:// URL which the filesystem can't read
+  //      directly — strip the scheme so cmp/install see a plain path.
   function notify(title, body) {
     var bin = Quickshell.env("OMARCHY_PATH") + "/bin/omarchy-notification-send"
     Quickshell.execDetached([bin, title, body])
   }
 
+  readonly property string homeDir: Quickshell.env("HOME") || ""
+  readonly property string binDir: homeDir + "/.local/bin"
+  readonly property string destPath: binDir + "/omarchy-dictionary-lookup"
+
+  // Util.fileUrl encodes every path segment, so Qt.resolvedUrl returns a
+  // percent-encoded URL.  decodeURIComponent turns it back into a real
+  // filesystem path that cmp/install can open.  The try/catch handles the
+  // edge case where the URL is already plain ASCII (no-op decode).
+  readonly property string scriptPath: {
+    var url = String(Qt.resolvedUrl("scripts/omarchy-dictionary-lookup"))
+    var raw = url.replace(/^file:\/\//, "/")
+    try { return decodeURIComponent(raw) } catch (e) { return raw }
+  }
+
   Process {
-    id: installProc
-    // Util.fileUrl encodes every path segment, so Qt.resolvedUrl returns a
-    // percent-encoded URL.  decodeURIComponent turns it back into a real
-    // filesystem path that cmp/install can open.  The try/catch handles the
-    // edge case where the URL is already plain ASCII (no-op decode).
-    property string scriptPath: {
-      var url = String(Qt.resolvedUrl("scripts/omarchy-dictionary-lookup"))
-      var raw = url.replace(/^file:\/\//, "/")
-      try { return decodeURIComponent(raw) } catch (e) { return raw }
-    }
-    command: ["sh", "-c",
-      "home=\"${HOME:-" + (Quickshell.env("HOME") || "/root") + "\"}; " +
-      "dst=\"$home/.local/bin/omarchy-dictionary-lookup\"; " +
-      "mkdir -p \"$home/.local/bin\" && " +
-      "if [ ! -f \"$dst\" ] || ! cmp -s '" + scriptPath + "' \"$dst\"; then " +
-      "  install -m755 '" + scriptPath + "' \"$dst\" && echo installed; " +
-      "fi"
-    ]
-    stdout: StdioCollector {
-      waitForEnd: true
-      onStreamFinished: {
-        if (text.indexOf("installed") !== -1) {
-          root.notify("Dictionary", "Installed system script: ~/.local/bin/omarchy-dictionary-lookup")
-        }
-      }
-    }
+    id: mkdirProc
+    command: ["mkdir", "-p", root.binDir]
     stderr: SplitParser {
       onRead: function(line) { console.warn("omarchy-dictionary install:", line) }
     }
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        console.warn("omarchy-dictionary install: mkdir failed for", root.binDir)
+        return
+      }
+      cmpProc.running = true
+    }
   }
 
-  Component.onCompleted: installProc.running = true
+  Process {
+    id: cmpProc
+    command: ["cmp", "-s", root.scriptPath, root.destPath]
+    stderr: SplitParser {
+      onRead: function(line) { console.warn("omarchy-dictionary install:", line) }
+    }
+    onExited: function(exitCode) {
+      // 0 = identical, stay silent. Anything else — differ (1) or
+      // missing/unreadable (2) — means install.
+      if (exitCode !== 0) installProc.running = true
+    }
+  }
+
+  Process {
+    id: installProc
+    command: ["install", "-m755", root.scriptPath, root.destPath]
+    stderr: SplitParser {
+      onRead: function(line) { console.warn("omarchy-dictionary install:", line) }
+    }
+    onExited: function(exitCode) {
+      if (exitCode === 0) {
+        root.notify("Dictionary", "Installed system script: ~/.local/bin/omarchy-dictionary-lookup")
+      } else {
+        console.warn("omarchy-dictionary install: install failed for", root.destPath)
+      }
+    }
+  }
+
+  Component.onCompleted: {
+    if (root.homeDir === "") {
+      console.warn("omarchy-dictionary install: HOME is empty, skipping script install")
+    } else {
+      mkdirProc.running = true
+    }
+  }
 
   Loader {
     id: panelLoader

--- a/Model.js
+++ b/Model.js
@@ -64,6 +64,11 @@ function languages() { return LANGUAGES }
 // the curl argv array that the QML Process element runs.
 function apiBase(langCode) {
   var code = String(langCode || defaultLanguage()).trim().toLowerCase() || defaultLanguage()
+  // Allowlist: only known Wiktionary editions may become a subdomain.
+  // Without this, a future caller passing an arbitrary string could turn
+  // the URL into an attacker domain via fragment/host tricks
+  // (e.g. "evil.com#"). Falls back to the default language.
+  if (!LANG_BY_VALUE[code]) code = defaultLanguage()
   return "https://" + code + ".wiktionary.org/w/api.php?action=query&prop=extracts&explaintext=1&format=json&titles="
 }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -374,6 +374,7 @@ Column {
                 if (root.status === "error") return "couldn't reach the API"
                 return "look up a word"
               }
+              textFormat: Text.PlainText
               color: Qt.darker(root.contentForeground, 1.4)
               font.family: root.contentFontFamily
               font.pixelSize: Style.font.caption
@@ -617,6 +618,7 @@ Column {
 
               Text {
                 text: "Looking up \"" + root.query + "\"…"
+                textFormat: Text.PlainText
                 color: Qt.darker(root.contentForeground, 1.3)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body
@@ -633,6 +635,7 @@ Column {
               Text {
                 width: parent.width
                 text: "No definition for \"" + (root.originalQuery || root.query) + "\"."
+                textFormat: Text.PlainText
                 color: Qt.darker(root.contentForeground, 1.0)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body
@@ -676,6 +679,7 @@ Column {
               Text {
                 width: parent.width
                 text: "No definition for \"" + root.query + "\"."
+                textFormat: Text.PlainText
                 color: Qt.darker(root.contentForeground, 1.0)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body
@@ -686,6 +690,7 @@ Column {
                 width: parent.width
                 visible: root.statusMessage !== ""
                 text: root.statusMessage
+                textFormat: Text.PlainText
                 color: Qt.darker(root.contentForeground, 1.5)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.caption
@@ -702,6 +707,7 @@ Column {
               Text {
                 width: parent.width
                 text: "Couldn't look up \"" + root.query + "\"."
+                textFormat: Text.PlainText
                 color: Qt.darker(root.contentForeground, 1.0)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body
@@ -711,6 +717,7 @@ Column {
               Text {
                 width: parent.width
                 text: root.statusMessage
+                textFormat: Text.PlainText
                 color: Qt.darker(root.contentForeground, 1.5)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.caption
@@ -736,6 +743,7 @@ Column {
             width: parent.width
             visible: root.isAutoMatched && root.originalQuery !== "" && root.entry !== null
             text: root.autoMatchedNote()
+            textFormat: Text.PlainText
             color: Qt.darker(root.contentForeground, 1.4)
             font.family: root.contentFontFamily
             font.pixelSize: Style.font.caption
@@ -750,6 +758,7 @@ Column {
             Text {
               id: wordText
               text: root.entryWord()
+              textFormat: Text.PlainText
               color: root.contentForeground
               font.family: root.contentFontFamily
               font.pixelSize: Style.font.display
@@ -762,6 +771,7 @@ Column {
             Text {
               id: phoneticLabel
               text: root.entryPhonetic()
+              textFormat: Text.PlainText
               color: Qt.darker(root.contentForeground, 1.3)
               font.family: root.contentFontFamily
               font.pixelSize: Style.font.body
@@ -775,6 +785,7 @@ Column {
             Text {
               id: sourceTag
               text: root.entry ? Model.sourceLabel(entry) : ""
+              textFormat: Text.PlainText
               color: Qt.darker(root.contentForeground, 1.55)
               font.family: root.contentFontFamily
               font.pixelSize: Style.font.caption
@@ -916,6 +927,70 @@ Column {
                 height: Style.space(4)
               }
             }
+          }
+        }
+
+        // ---------- Hotkey script footer ----------
+        // Explicit opt-in install for the SUPER+D selection lookup.
+        // Nothing is written to ~/.local/bin/ until the user clicks
+        // Install. Status comes from the host BarWidget
+        // (installStatus/installMessage) which runs the mkdir/cmp/install
+        // stages shell-free.
+        PanelSeparator {
+          foreground: root.contentForeground
+        }
+
+        Column {
+          width: parent.width
+          spacing: Style.space(6)
+
+          Row {
+            width: parent.width
+            spacing: Style.space(10)
+
+            Text {
+              id: installLabel
+              text: "Install hotkey script"
+              textFormat: Text.PlainText
+              color: root.contentForeground
+              font.family: root.contentFontFamily
+              font.pixelSize: Style.font.body
+              elide: Text.ElideRight
+              width: parent.width - installButton.width - Style.space(10)
+              anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Button {
+              id: installButton
+              text: "Install"
+              enabled: root.hostWidget ? root.hostWidget.installStatus !== "working" : true
+              onClicked: {
+                if (root.hostWidget && typeof root.hostWidget.installHotkeyScript === "function")
+                  root.hostWidget.installHotkeyScript()
+              }
+              foreground: root.contentForeground
+            }
+          }
+
+          Text {
+            width: parent.width
+            visible: text !== ""
+            text: root.hostWidget ? root.hostWidget.installMessage : ""
+            textFormat: Text.PlainText
+            color: Qt.darker(root.contentForeground, 1.4)
+            font.family: root.contentFontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
+          }
+
+          Text {
+            width: parent.width
+            text: "Enables SUPER+D lookup. Installs to ~/.local/bin/."
+            textFormat: Text.PlainText
+            color: Qt.darker(root.contentForeground, 1.7)
+            font.family: root.contentFontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -50,16 +50,18 @@ word in any application:
 o.bind("SUPER + D", "Look up selection in dictionary", "omarchy-dictionary-lookup")
 ```
 
-The plugin auto-installs the bundled `scripts/omarchy-dictionary-lookup` to
-`~/.local/bin/` on first load (idempotent — re-runs only when the bundled
-copy changes), so no manual install step is needed. The script reads the
+The plugin bundles `scripts/omarchy-dictionary-lookup` but never installs
+it on its own. Open the dictionary panel and use the
+**Install hotkey script** section at the bottom (border-separated footer
+with an Install button) to copy it to `~/.local/bin/` (idempotent —
+re-runs only when the bundled copy changes). The script reads the
 Wayland primary selection (highlighted text), falls back to the clipboard
 if empty, extracts the first alphabetic word, and opens the dictionary
 panel with that word pre-filled. With nothing selected it just opens the
 empty panel.
 
-> **Note:** A desktop notification confirms when the script is first
-> installed. You may want to inspect it before use — review
+> **Note:** A desktop notification confirms when the script is installed.
+> You may want to inspect it before use — review
 > `scripts/omarchy-dictionary-lookup` in the plugin repo, or run
 > `cat ~/.local/bin/omarchy-dictionary-lookup` to see what was installed.
 

--- a/tests/install.test.js
+++ b/tests/install.test.js
@@ -3,17 +3,25 @@
 
 // Tests for the auto-install mechanism in BarWidget.qml.
 //
-// The QML Process builds a shell command that copies the lookup script from
-// the plugin's scripts/ directory to ~/.local/bin/.  This test suite
-// exercises the two key pieces that were fixed in issue #5:
+// The QML widget copies the lookup script from the plugin's scripts/
+// directory to ~/.local/bin/ in three shell-free Process stages with paths
+// passed as argv (never interpolated into an `sh -c` string, so quoting can
+// never break):
+//
+//   1. mkdir -p ~/.local/bin        (the dir is not assumed to exist on a
+//                                     fresh install)
+//   2. cmp -s <src> <dst>           (exit 0 = identical, stay silent)
+//   3. install -m755 <src> <dst>    (only when cmp reported differ/missing)
+//
+// This suite exercises the two key pieces:
 //
 //   1. decodeURIComponent on the Qt.resolvedUrl path — Util.fileUrl
 //      encodes every path segment, so the resolved URL can contain %20
 //      or other percent-encoding that breaks cmp/install if not decoded.
 //
-//   2. The shell install command itself — it must correctly detect when
-//      the destination is missing or stale, copy the source, and only
-//      echo "installed" when install(1) actually ran.
+//   2. The staged install itself — it must correctly detect when
+//      the destination is missing or stale, copy the source, and stay
+//      silent when the destination already matches.
 //
 // Run:  node tests/install.test.js
 
@@ -21,7 +29,7 @@ var assert = require("assert");
 var path   = require("path");
 var fs     = require("fs");
 var os     = require("os");
-var { execSync } = require("child_process");
+var { execFileSync } = require("child_process");
 
 // ── Minimal test harness ───────────────────────────────────────────────────
 var _group = "";
@@ -109,38 +117,33 @@ test("returns raw path if decodeURIComponent throws", () => {
   assert.ok(result.indexOf("%ZZbad") !== -1, "should keep the malformed percent sequence");
 });
 
-// ── Shell install command logic ────────────────────────────────────────────
-// The QML Process builds this shell command:
-//
-//   home="${HOME:-<fallback>}"; dst="$home/.local/bin/omarchy-dictionary-lookup";
-//   mkdir -p "$home/.local/bin" &&
-//   if [ ! -f "$dst" ] || ! cmp -s '<src>' "$dst"; then
-//     install -m755 '<src>' "$dst" && echo installed;
-//   fi
-//
-// We test a simplified version that targets a temp directory.
+// ── Staged install logic ───────────────────────────────────────────────────
+// Mirrors the QML stages in BarWidget.qml (mkdirProc → cmpProc → installProc),
+// with paths passed as argv just like the QML `command` lists — no shell, no
+// quoting. Returns "installed" when install(1) ran, "" when the destination
+// already matched (silent) or the install failed.
 
 var SRC = path.join(__dirname, "..", "scripts", "omarchy-dictionary-lookup");
 
 function runInstall(src, dst) {
-  // Write a small shell script to avoid JSON.stringify quoting hell.
-  var script = [
-    "#!/bin/sh",
-    "set -eu",
-    "dst=" + dst,
-    "mkdir -p \"$(dirname \"$dst\")\"",
-    "if [ ! -f \"$dst\" ] || ! cmp -s '" + src + "' \"$dst\"; then",
-    "  install -m755 '" + src + "' \"$dst\" && echo installed",
-    "fi"
-  ].join("\n");
-  var tmp = path.join(os.tmpdir(), "dict-test-" + process.pid + "-" + Date.now() + ".sh");
-  fs.writeFileSync(tmp, script, { mode: 0o755 });
   try {
-    return execSync(tmp, { encoding: "utf8", timeout: 5000 }).trim();
+    execFileSync("mkdir", ["-p", path.dirname(dst)]);
   } catch (e) {
-    return (e.stdout || "").trim();
-  } finally {
-    try { fs.unlinkSync(tmp); } catch (_) {}
+    return "";
+  }
+  var same = false;
+  try {
+    execFileSync("cmp", ["-s", src, dst]);
+    same = true;
+  } catch (e) {
+    same = false;
+  }
+  if (same) return "";
+  try {
+    execFileSync("install", ["-m755", src, dst]);
+    return "installed";
+  } catch (e) {
+    return "";
   }
 }
 

--- a/tests/install.test.js
+++ b/tests/install.test.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 "use strict";
 
-// Tests for the auto-install mechanism in BarWidget.qml.
+// Tests for the manual-install mechanism in BarWidget.qml (triggered by the
+// panel footer's Install button via installHotkeyScript()).
 //
 // The QML widget copies the lookup script from the plugin's scripts/
 // directory to ~/.local/bin/ in three shell-free Process stages with paths

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -164,7 +164,7 @@ group("apiBase", function () {
   });
   test("'th' → th.wiktionary.org", function () { assert(M.apiBase("th").indexOf("https://th.wiktionary.org") === 0); });
   test("'ja' → ja.wiktionary.org", function () { assert(M.apiBase("ja").indexOf("https://ja.wiktionary.org") === 0); });
-  test("unknown 'xx' still builds URL", function () { assert(M.apiBase("xx").indexOf("xx.wiktionary.org") > -1); });
+  test("unknown 'xx' falls back to en (allowlist)", function () { assert(M.apiBase("xx").indexOf("en.wiktionary.org") > -1); });
   test("trims + lowercases", function () { assert(M.apiBase("  TH  ").indexOf("th.wiktionary.org") > -1); });
   test("whitespace-only falls back to en", function () { assert(M.apiBase("   ").indexOf("en.wiktionary.org") > -1); });
 });
@@ -952,13 +952,13 @@ group("parseWiktionaryWikitext — fallback/edges", function () {
 // 25 — apiBase: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 group("apiBase — edge cases", function () {
-  test("very short code 'a' builds URL", function () {
+  test("very short code 'a' falls back to en (allowlist)", function () {
     var u = M.apiBase("a");
-    assert(u.indexOf("https://a.wiktionary.org") > -1);
+    assert(u.indexOf("https://en.wiktionary.org") > -1);
   });
-  test("numeric code '123' builds URL", function () {
+  test("numeric code '123' falls back to en (allowlist)", function () {
     var u = M.apiBase("123");
-    assert(u.indexOf("https://123.wiktionary.org") > -1);
+    assert(u.indexOf("https://en.wiktionary.org") > -1);
   });
   test("URL always ends with 'titles='", function () {
     ["en", "th", "ja", "ko", "fr", "de"].forEach(function (c) {


### PR DESCRIPTION
Security hardening on top of the shell-free install stages:

- Manual opt-in hotkey install: removed Component.onCompleted auto-install to ~/.local/bin. Panel footer now has a bordered 'Install hotkey script' section with an Install button driving mkdir/cmp/install via installHotkeyScript() + installStatus/installMessage.
- XSS: Text.PlainText on all user/remote echo Texts (loading, notfound, error, suggestions, auto-match note, word/phonetic/source, hero summary).
- notify(): guard empty OMARCHY_PATH instead of execing /bin/...
- apiBase(): allowlist langCode against LANGUAGES, fallback to en.
- README + install.test.js comments updated; model.test.js expectations updated for allowlist fallback.

Tests: 2 lint + 240 model + 22 lookup + 14 install, all passing.